### PR TITLE
Fix cross compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ structopt = "0.3.20"
 log = "0.4.11"
 env_logger = "0.8.1"
 pretty_env_logger = "0.4.0"
+
+# fix cross-compile
+gmp-mpfr-sys = { features=["force-cross"] }


### PR DESCRIPTION
This PR is in response to #21.

One thing I'd suggest is to confirm that, in a standard environment, it doesn't extend the build time of a clean build too much. Since I was never able to cross-compile without this, I'm unsure what impact it has, but compile time is pretty long.