### PR TITLE
Added build status badge to README.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 on: [push, pull_request]
 
-name: Continuous Integration
-
 jobs:
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cncli
 A community-based cardano-node CLI tool. It's a collection of utilities to enhance and extend beyond those available with the `cardano-cli`
 
+![Build Status](https://github.com/AndrewWestberg/cncli/workflows/.github/workflows/ci.yml/badge.svg)
+
 #### Contributors
 CNCLI is provided free of charge to the Cardano Stakepool operator community. If you want to support its continued development, you can delegate or recommend the pools of our contributors.
  * Andrew Westberg - BCSH


### PR DESCRIPTION
This commit adds a build status badge to the README.md file. Workflows must not have an assigned name in order for build badges to render correctly when referred to by the workflow file path. Hence this pull request also removes the ci workflow name from configuration. The badge may therefore not render when previewed in the pull request as the change has not yet taken effect.