### PR TITLE
#34 Added windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,19 @@
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true # recurse submodules
-      - name: Install Toolchain
+      - name: Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           override: true
-          components: rustfmt, clippy
-      - name: Install Dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf
-      - name: Install Dependencies (MacOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install autoconf automake libtool
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-      - name: Lint
+      - name: Format
         uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -41,12 +23,71 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  windows:
+    name: Build Windows
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true # recurse submodules
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          system: MINGW64
+          install: >-
+            git
+            base-devel
+            mingw64/mingw-w64-x86_64-rust
+      - name: Build Libsodium
+        run: autorecon -vfi && ./configure && make
+        working-directory: contrib/libsodium
+      - name: Test
+        run: cargo test --features external-contrib-build
+
+  macos:
+    name: Build MacOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true # recurse submodules
+      - name: Install Dependencies (MacOS)
+        run: brew install autoconf automake libtool
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+
+  linux:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true # recurse submodules
+      - name: Install Dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             base-devel
             mingw64/mingw-w64-x86_64-rust
       - name: Build Libsodium
-        run: autorecon -vfi && ./configure && make
+        run: autoreconf -vfi && ./configure && make
         working-directory: contrib/libsodium
       - name: Test
         run: cargo test --features external-contrib-build
@@ -67,7 +67,6 @@ jobs:
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: test
 
   linux:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ gmp-mpfr-sys = { version="1.4", features=["force-cross"] }
 
 [build-dependencies]
 autotools = "0.2"
+
+[features]
+external-contrib-build = []

--- a/build.rs
+++ b/build.rs
@@ -18,9 +18,20 @@ fn main() {
             .arg("--force")
     });
 
-    let libsodium = autotools::Config::new("contrib/libsodium/").reconf("-vfi").build();
-    println!("cargo:rustc-link-search=native={}", libsodium.join("lib").display());
-    println!("cargo:rustc-link-lib=static=sodium");
+    // Build contrib automatically (as part of rust build)
+    #[cfg(not(feature = "external-contrib-build"))]
+    {
+        let libsodium = autotools::Config::new("contrib/libsodium/").reconf("-vfi").build();
+        println!("cargo:rustc-link-search=native={}", libsodium.join("lib").display());
+        println!("cargo:rustc-link-lib=static=sodium");
+    }
+
+    // Expect contrib to be pre-built (external to rust build) - necessary when using
+    // MSYS2/MinGW64 to build.
+    #[cfg(feature = "external-contrib-build")]
+    {
+        println!("cargo:rustc-link-search=contrib/libsodium/src/libsodium/.libs");
+    }
 
     println!("cargo:return-if-changed=build.rs");
 }


### PR DESCRIPTION
This commit adds builds for Windows as well as:

* Removes "check" stage of builds as it is unnecessary if running test
* Moved Lint action to its own job so that it can execute in parallel
* Moved each os build into its own job so that they can specify their own build matrix for different targets
* Removed creation of binaries (will do this as part of #35)