### PR TITLE
add flake.nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 [[package]]
 name = "cardano_ouroboros_network"
 version = "0.2.0-dev"
-source = "git+https://github.com/AndrewWestberg/rust-cardano-ouroboros-network?rev=524b44b#524b44bcad1b17d5570a42e3b5c9651d38db55ae"
+source = "git+https://github.com/AndrewWestberg/rust-cardano-ouroboros-network?rev=524b44bcad1b17d5570a42e3b5c9651d38db55ae#524b44bcad1b17d5570a42e3b5c9651d38db55ae"
 dependencies = [
  "blake2b_simd",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bigdecimal = "0.2.0"
 num-bigint = "0.3.1"
 blake2b_simd = "0.5.11"
 byteorder = "1.3.4"
-cardano_ouroboros_network = { git = "https://github.com/AndrewWestberg/rust-cardano-ouroboros-network", rev = "524b44b" }
+cardano_ouroboros_network = { git = "https://github.com/AndrewWestberg/rust-cardano-ouroboros-network", rev = "524b44bcad1b17d5570a42e3b5c9651d38db55ae" }
 #cardano_ouroboros_network = { path = "/home/westbam/Development/rust-cardano-ouroboros-network" }
 chrono = "0.4.19"
 chrono-tz = "0.5.3"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "iohk-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1615911315,
+        "narHash": "sha256-3GiYZendBOpHfgDkfBI/GJfhJ3hOdd/fDq8VWSMdtng=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "bc4216c5b0e14dbde5541763f4952f99c3c712fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1615797423,
+        "narHash": "sha256-5NGDZXPQzuoxf/42NiyC9YwwhwzfMfIRrz3aT0XHzSc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "266dc8c3d052f549826ba246d06787a219533b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "iohk-nix": "iohk-nix",
+        "nixpkgs": "nixpkgs",
+        "rust-nix": "rust-nix",
+        "utils": "utils"
+      }
+    },
+    "rust-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1614256663,
+        "narHash": "sha256-cFew8eXUJfmlaLh4f3Z+TxAAo2Syh2xWB/3Xa/Ebd70=",
+        "owner": "input-output-hk",
+        "repo": "rust.nix",
+        "rev": "e2d4e8e5225739c4607614f98f60d2667c794558",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "work",
+        "repo": "rust.nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1613500319,
+        "narHash": "sha256-ybAq6pImFCSnwyhhmnnvV567JM4GuhCEG/PHBkSS86U=",
+        "owner": "kreisys",
+        "repo": "flake-utils",
+        "rev": "28e72370213c9bc2cf094ab07b8ac95f3c6bb60f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kreisys",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:kreisys/flake-utils";
+    rust-nix.url = "github:input-output-hk/rust.nix/work";
+    rust-nix.inputs.nixpkgs.follows = "nixpkgs";
+    iohk-nix = {
+      url = "github:input-output-hk/iohk-nix";
+      flake = false;
+    };
+  };
+  outputs = { self, nixpkgs, utils, rust-nix, iohk-nix }:
+    utils.lib.simpleFlake {
+      inherit nixpkgs;
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      preOverlays = [ rust-nix (iohk-nix + /overlays/crypto) ];
+      overlay = final: prev:
+        let lib = prev.lib;
+        in {
+          fakeGit = final.writeShellScriptBin "git" "true";
+          cncli = final.rust-nix.buildPackage {
+            inherit ((builtins.fromTOML
+              (builtins.readFile ./Cargo.toml)).package)
+              name version;
+            root = ./.;
+            nativeBuildInputs = with final; [
+              pkg-config
+              protobuf
+              rustfmt
+              fakeGit
+              m4
+              autoconf
+              automake
+            ];
+
+            cargoBuildOptions = x: x ++ [ "--features" "libsodium-sys" ];
+            buildInputs = with final; [ openssl libsodium ];
+
+            PROTOC = "${final.protobuf}/bin/protoc";
+            PROTOC_INCLUDE = "${final.protobuf}/include";
+          };
+        };
+      packages = { cncli }@pkgs: pkgs;
+      devShell = { mkShell, rustc, cargo, pkg-config, openssl, protobuf }:
+        mkShell {
+          PROTOC = "${protobuf}/bin/protoc";
+          PROTOC_INCLUDE = "${protobuf}/include";
+          buildInputs = [ rustc cargo pkg-config openssl protobuf ];
+        };
+    };
+}


### PR DESCRIPTION
This adds a nix flake that allows someone to utilize cncli by adding the overlay attribute to their nixos configuration. It requires that the cargo.toml always specifies the full gitrev instead of the short rev (which is why a new lock file was needed to be generated.