### PR TITLE
[#83] Add support for leaderlog on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ CNCLI is provided free of charge to the Cardano stake pool operator community. I
 - [Andrew Westberg](https://github.com/AndrewWestberg) - [**BCSH**](https://bluecheesestakehouse.com/)
 - [Michael Fazio](https://github.com/michaeljfazio) - [**SAND**](https://www.sandstone.io/)
 - [Andrea Callea](https://github.com/gacallea/) - [**SALAD**](https://insalada.io/)
+- [Thomas Diesler](https://github.com/tdiesler/) - [**ASTOR**](http://astorpool.net/)
 
 ### Contributing
 


### PR DESCRIPTION
Add a naive Nix shell that can eventually be used to build cncli on all supported target platforms

[DO NOT MERGE]

This PR is merely here to document that there is work happening to support arm64. Perhaps this can get added to some dedicated feature branch that we can share/work on?